### PR TITLE
Prevents unnecessary checking of var length

### DIFF
--- a/src/protected/vendor/yiisoft/yii/framework/web/js/source/jquery.ajaxqueue.js
+++ b/src/protected/vendor/yiisoft/yii/framework/web/js/source/jquery.ajaxqueue.js
@@ -100,7 +100,7 @@ $(function(){
 				synced[ pos ].done = true;
 		
 				if ( pos == 0 || !synced[ pos-1 ] )
-					for ( var i = pos; i < synced.length && synced[i].done; i++ ) {
+					for ( var i = pos, l=synced.length ; i < l && synced[i].done; i++ ) {
 						if ( synced[i].error ) synced[i].error.apply( jQuery, syncedData[i].error );
 						if ( synced[i].success ) synced[i].success.apply( jQuery, syncedData[i].success );
 						if ( synced[i].complete ) synced[i].complete.apply( jQuery, syncedData[i].complete );

--- a/src/protected/vendor/yiisoft/yii/framework/web/js/source/jquery.cookie.js
+++ b/src/protected/vendor/yiisoft/yii/framework/web/js/source/jquery.cookie.js
@@ -78,7 +78,7 @@ jQuery.cookie = function(name, value, options) {
         var cookieValue = null;
         if (document.cookie && document.cookie != '') {
             var cookies = document.cookie.split(';');
-            for (var i = 0; i < cookies.length; i++) {
+            for (var i = 0,l= cookies.length ; i < l; i++) {
                 var cookie = jQuery.trim(cookies[i]);
                 // Does this cookie string begin with the name we want?
                 if (cookie.substring(0, name.length + 1) == (name + '=')) {

--- a/src/www/js/html5_for_ie.js
+++ b/src/www/js/html5_for_ie.js
@@ -1,1 +1,1 @@
-(function(){if(!/*@cc_on!@*/0)return;var e="abbr,article,aside,audio,bb,canvas,datagrid,datalist,details,dialog,eventsource,figure,footer,header,hgroup,mark,menu,meter,nav,output,progress,section,time,video".split(',');for(var i=0;i<e.length;i++){document.createElement(e[i])}})()
+(function(){if(!/*@cc_on!@*/0)return;var e="abbr,article,aside,audio,bb,canvas,datagrid,datalist,details,dialog,eventsource,figure,footer,header,hgroup,mark,menu,meter,nav,output,progress,section,time,video".split(',');for(var i=0, eLen = e.length;i<eLen;i++){document.createElement(e[i])}})()


### PR DESCRIPTION
The js engine will check the var each time, but since the length will not change why not just use a var to increase speed?  (Not this is a trivial calculation, but let's use best practices c'mon!)
