### PR TITLE
Removed outline on search input field

### DIFF
--- a/src/www/css/opb.css
+++ b/src/www/css/opb.css
@@ -193,6 +193,7 @@ input[name=q] {
     -webkit-transition: all .5s ease;
     -moz-transition: all .5s ease;
     -o-transition: all .5s ease;
+    outline: none;
 }
 
 input[name=q]:focus {


### PR DESCRIPTION
I felt this change was necessary because the default WebKit outline didn't look very good with OPB's styled search field. This change is purely cosmetic and very minor.
