### PR TITLE
Added Dockerfile for rapid deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM      tutum/lamp:latest
+
+RUN       rm -rf /app
+COPY      . /app
+
+RUN       mkdir -p /app/src/www/assets && \
+          chown -R www-data /app/src
+
+EXPOSE    80 3306
+
+CMD       ["./run.sh"]


### PR DESCRIPTION
By building an image from this Dockerfile, users can quickly setup a container running openbay without any additional setup:

``` sh
$ docker build -t openbay .
$ docker run -d -p 80:80 openbay
```

Additionally, an automated build[1] can be created on Docker Hub to automatically build images of this Dockerfile, so all a user needs to do is pull the image.

See:
- #31 for more info.
- [1] [http://docs.docker.com/docker-hub/builds/](http://docs.docker.com/docker-hub/builds/)
