### PR TITLE
LTorrent: log stack trace as _string_

### DIFF
--- a/src/protected/models/LTorrent.php
+++ b/src/protected/models/LTorrent.php
@@ -420,7 +420,7 @@ class LTorrent extends CActiveRecord
                 Yii::app()->cache->set($key, $torrentsIds);
             }
         } catch (Exception $e) {
-            Yii::log('getLastTorrentIdsByCategories failed. Exception: ' . $e->getMessage() . PHP_EOL . 'Trace: ' . $e->getTrace(), CLogger::LEVEL_ERROR);
+            Yii::log('getLastTorrentIdsByCategories failed. Exception: ' . $e->getMessage() . PHP_EOL . 'Trace: ' . $e->getTraceAsString(), CLogger::LEVEL_ERROR);
 
             if (YII_DEBUG) {
                 throw $e;


### PR DESCRIPTION
s/getTrace()/getTraceAsString()/
getTrace() returns an array where as getTraceAsString() gives
the trace as string
avoids the notice 'Array to string conversion'.

Signed-off-by: Arjun Sreedharan arjun024@gmail.com
