### PR TITLE
Prevent potential security issues arising from using untrusted IP addresses

### DIFF
--- a/src/protected/components/AHttpRequest.php
+++ b/src/protected/components/AHttpRequest.php
@@ -21,16 +21,40 @@ class AHttpRequest extends CHttpRequest
     }
 
     /**
-     * Returns the user IP address.
+     * Tries to determine the user's IP address
      *
-     * @see http://stackoverflow.com/a/916157
+     * Note that this method does not return the actual IP address of the user
+     * when the user connects from behind for example a proxy (the IP address
+     * of the proxy will be returned in that case)
+     *
      * @return string user IP address
      */
     public function getUserHostAddress()
     {
-        if (! is_null($this->$ipAddress)) {
-            return $this->$ipAddress;
+        if (isset($_SERVER['REMOTE_ADDR']) && $this->validateIp($_SERVER['REMOTE_ADDR'])) {
+            return $this->ipAddress = $_SERVER['REMOTE_ADDR'];
         }
+
+        // NOTE: or use something like this 127.0.0.2
+        return ($this->ipAddress = '0.0.0.0');
+    }
+
+    /**
+     * Tries to determine the user's "real" IP address
+     *
+     * This method tries to find the user's IP address even when the user makes
+     * requests from behind a proxy. This method should *not* be used for validating
+     * whether a user is allowed access because the only thing that can be trusted
+     * is $_SERVER['REMOTE_ADDR']
+     *
+     * @return string user IP address
+     */
+    public function getUnsafeUserHostAddress()
+    {
+        if (!is_null($this->ipAddress)) {
+            return $this->ipAddress;
+        }
+
         foreach (array(
             'HTTP_X_REAL_IP',
             'HTTP_CLIENT_IP',
@@ -43,23 +67,36 @@ class AHttpRequest extends CHttpRequest
         ) as $key) {
             if (array_key_exists($key, $_SERVER) === true) {
                 foreach (explode(',', $_SERVER[$key]) as $ip) {
-                    $ip = trim($ip);
-                    // Allow only IPv4 address, Deny reserved addresses, Deny private addresses
-                    if (filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4 | FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE) !== false) {
-                        return ($this->$ipAddress = $ip);
+                    if ($this->validateIp(trim($ip))) {
+                        return ($this->ipAddress = $ip);
                     }
                 }
             }
         }
+
         // NOTE: or use something like this 127.0.0.2
-        return ($this->$ipAddress = '0.0.0.0');
+        return ($this->ipAddress = '0.0.0.0');
+    }
+
+    /**
+     * Validates an IP address
+     *
+     * Allows only IPv4 address, Denies reserved addresses and private addresses
+     *
+     * @param string $ipAddress The IP address to validate
+     *
+     * @return bool True when the Ip address is valid
+     */
+    private function validateIp($ipAddress)
+    {
+        return filter_var($ipAddress, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4 | FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE) !== false;
     }
 
     public function getCountryCode()
     {
         if (empty($this->countryCode) && ! YII_DEBUG) {
             if (empty(Yii::app()->request->cookies['country_code'])) {
-                $this->countryCode = geoip_country_code_by_name($this->getUserHostAddress());
+                $this->countryCode = geoip_country_code_by_name($this->getUnsafeUserHostAddress());
                 Yii::app()->request->cookies['country_code'] = new CHttpCookie('country_code', $this->countryCode, array(
                     'expire' => time() + 86400
                 ));


### PR DESCRIPTION
Currently [this](https://github.com/isohuntto/openbay/blob/master/src/protected/components/AHttpRequest.php#L35-L42) list of server variables is checked to find the client's IP address:

    array(
        'HTTP_X_REAL_IP',
        'HTTP_CLIENT_IP',
        'HTTP_X_FORWARDED_FOR',
        'HTTP_X_FORWARDED',
        'HTTP_X_CLUSTER_CLIENT_IP',
        'HTTP_FORWARDED_FOR',
        'HTTP_FORWARDED',
        'REMOTE_ADDR'
    )

which means that when at some point the [`CAccessControlFilter`](https://github.com/isohuntto/openbay/blob/master/src/protected/vendor/yiisoft/yii/framework/web/auth/CAccessControlFilter.php) is used to validate a user based on the IP address it is trivially exploitable, because everybody can easily fake any of those values (except for the `REMOTE_ADDR`) potentially allowing an attacker access.

An example of where it is incorrectly used in security context and where it is a potential vulnerability is [`CAccessControlFilter::preFilter()`](https://github.com/isohuntto/openbay/blob/master/src/protected/vendor/yiisoft/yii/framework/web/auth/CAccessControlFilter.php#L134).

This PR fixes this to only use `REMOTE_ADDR` when trying to get the client's IP in security contexts. The original method is renamed with the `Unsafe` prefix so it can still be used to try to determine the location of the client using geoip.

This PR also fixes the errors introduced in https://github.com/isohuntto/openbay/commit/030b6e2cd48f57cc8867cadce0c5da7f15b4bfa9 (ping @writemorecode).