### PR TITLE
Fixed a slight typo.

### DIFF
--- a/conf/example-nginx.conf
+++ b/conf/example-nginx.conf
@@ -40,6 +40,6 @@ server {
         fastcgi_param  SCRIPT_FILENAME  $document_root$fsn;
         fastcgi_param  PATH_INFO        $fastcgi_path_info;
         fastcgi_param  PATH_TRANSLATED  $document_root$fsn;
-        fastcgi_param  HTTPS $https_value;
+        fastcgi_param  HTTPS $https;
     }
 }


### PR DESCRIPTION
FastCgi uses $https instead of $https_value